### PR TITLE
Removing extra willChangeValueForKey and didChangeValueForKey methods

### DIFF
--- a/ITSwitch/ITSwitch.m
+++ b/ITSwitch/ITSwitch.m
@@ -308,11 +308,7 @@
 }
 
 - (void)setTarget:(id)target {
-    [self willChangeValueForKey:@"target"];
-    {
-        _target = target;
-    }
-    [self didChangeValueForKey:@"target"];
+    _target = target;
 }
 
 - (SEL)action {
@@ -320,11 +316,7 @@
 }
 
 - (void)setAction:(SEL)action {
-    [self willChangeValueForKey:@"action"];
-    {
-        _action = action;
-    }
-    [self didChangeValueForKey:@"action"];
+    _action = action;
 }
 
 
@@ -352,11 +344,7 @@
 }
 
 - (void)setTintColor:(NSColor *)tintColor {
-    [self willChangeValueForKey:@"tintColor"];
-    {
-        _tintColor = tintColor;
-    }
-    [self didChangeValueForKey:@"tintColor"];
+    _tintColor = tintColor;
     
     [self reloadLayer];
 }


### PR DESCRIPTION
Hey thanks for sharing the switch control! I have the following suggestion: 

In properties where you don't have a custom setter name like target, action and tint colour you shouldn't invoke `willChangeValueForKey:` and `didChangeValueForKey:` , since KVO runtime magic will do it as well. This results on getting twice the change notification.

For `setEnabled:` and `setOn:` is correctly done because KVO can't figure out where to add the will/did change calls.

Alternatively, you could opt out with `automaticallyNotifiesObserversForKey:`

Correct me if I am wrong.
