### PR TITLE
Add IB_DESIGNABLE and IBInspectable directives to ITSwitch

### DIFF
--- a/ITSwitch/ITSwitch.h
+++ b/ITSwitch/ITSwitch.h
@@ -11,16 +11,17 @@
 /**
  *  ITSwitch is a replica of UISwitch for Mac OS X
  */
+IB_DESIGNABLE
 @interface ITSwitch : NSControl
 
 /**
  *  @property on - Gets or sets the switches state
  */
-@property (nonatomic, getter=isOn) BOOL on;
+@property (nonatomic, getter=isOn) IBInspectable BOOL on;
 
 /**
  *  @property tintColor - Gets or sets the switches tint
  */
-@property (nonatomic, strong) NSColor *tintColor;
+@property (nonatomic, strong) IBInspectable NSColor *tintColor;
 
 @end


### PR DESCRIPTION
This allows you to preview and edit the appearance of an ITSwitch in Xcode 6's IB. The shadow gets clipped because of the way that IB_DESIGNABLE views are rendered, but that seems reasonable.

![screenshot 2014-11-12 22 57 21](https://cloud.githubusercontent.com/assets/594059/5023958/46743abe-6abf-11e4-928f-d336e5ea53ff.png)
