### PR TITLE
Fix: Click on switch, click any menu, click in anywhere in the window, switch responds

### DIFF
--- a/ITSwitch/ITSwitch.m
+++ b/ITSwitch/ITSwitch.m
@@ -274,6 +274,7 @@ static CGFloat const kDisabledOpacity = 0.5f;
 }
 
 - (void)mouseUp:(NSEvent *)theEvent {
+	if (!self.active) return;
     if (!self.isEnabled) return;
 
     self.active = NO;


### PR DESCRIPTION
Fixes issue where once a switch is mark active (by clicking on it), clicking anywhere else will trigger it on -mouseUp:.

Reproducible with the demo project included in repo.