### PR TITLE
Expose the option to modify disabled border color

### DIFF
--- a/ITSwitch/ITSwitch.h
+++ b/ITSwitch/ITSwitch.h
@@ -24,4 +24,9 @@ IB_DESIGNABLE
  */
 @property (nonatomic, strong) IBInspectable NSColor *tintColor;
 
+/**
+ *  @property disabledBorderColor - Define the switch's border color for disabled state.
+ */
+@property (nonatomic, strong) IBInspectable NSColor *disabledBorderColor;
+
 @end

--- a/ITSwitch/ITSwitch.m
+++ b/ITSwitch/ITSwitch.m
@@ -31,7 +31,6 @@ static CGFloat const kDisabledOpacity = 0.5f;
 
 #define kKnobBackgroundColor [NSColor colorWithCalibratedWhite:1.f alpha:1.f]
 
-#define kDisabledBorderColor [NSColor colorWithCalibratedWhite:0.f alpha:0.2f]
 #define kDisabledBackgroundColor [NSColor clearColor]
 #define kDefaultTintColor [NSColor colorWithCalibratedRed:0.27f green:0.86f blue:0.36f alpha:1.f]
 #define kInactiveBackgroundColor [NSColor colorWithCalibratedWhite:0 alpha:0.3]
@@ -94,6 +93,11 @@ static CGFloat const kDisabledOpacity = 0.5f;
 - (void)setUp {
     // The Switch is enabled per default
     self.enabled = YES;
+    
+    // Set the default border color if not present
+    if (!self.disabledBorderColor) {
+        self.disabledBorderColor = [NSColor colorWithCalibratedWhite:0.f alpha:0.2f];
+    }
     
     // Set up the layer hierarchy
     [self setUpLayers];
@@ -190,7 +194,7 @@ static CGFloat const kDisabledOpacity = 0.5f;
             _backgroundLayer.borderColor = [self.tintColor CGColor];
             _backgroundLayer.backgroundColor = [self.tintColor CGColor];
         } else {
-            _backgroundLayer.borderColor = [kDisabledBorderColor CGColor];
+            _backgroundLayer.borderColor = [self.disabledBorderColor CGColor];
             _backgroundLayer.backgroundColor = [kDisabledBackgroundColor CGColor];
         }
         
@@ -358,6 +362,12 @@ static CGFloat const kDisabledOpacity = 0.5f;
 
 - (void)setTintColor:(NSColor *)tintColor {
     _tintColor = tintColor;
+    
+    [self reloadLayer];
+}
+
+- (void)setDisabledBorderColor:(NSColor *)disabledBorderColor {
+    _disabledBorderColor = disabledBorderColor;
     
     [self reloadLayer];
 }

--- a/ITSwitch/ITSwitch.m
+++ b/ITSwitch/ITSwitch.m
@@ -31,6 +31,7 @@ static CGFloat const kDisabledOpacity = 0.5f;
 
 #define kKnobBackgroundColor [NSColor colorWithCalibratedWhite:1.f alpha:1.f]
 
+#define kDisabledBorderColor [NSColor colorWithCalibratedWhite:0.f alpha:0.2f]
 #define kDisabledBackgroundColor [NSColor clearColor]
 #define kDefaultTintColor [NSColor colorWithCalibratedRed:0.27f green:0.86f blue:0.36f alpha:1.f]
 #define kInactiveBackgroundColor [NSColor colorWithCalibratedWhite:0 alpha:0.3]
@@ -64,7 +65,7 @@ static CGFloat const kDisabledOpacity = 0.5f;
 // ---------------------------------------------------------------------------------------
 
 @implementation ITSwitch
-@synthesize tintColor = _tintColor;
+@synthesize tintColor = _tintColor, disabledBorderColor = _disabledBorderColor;
 
 
 
@@ -93,11 +94,6 @@ static CGFloat const kDisabledOpacity = 0.5f;
 - (void)setUp {
     // The Switch is enabled per default
     self.enabled = YES;
-    
-    // Set the default border color if not present
-    if (!self.disabledBorderColor) {
-        self.disabledBorderColor = [NSColor colorWithCalibratedWhite:0.f alpha:0.2f];
-    }
     
     // Set up the layer hierarchy
     [self setUpLayers];
@@ -364,6 +360,12 @@ static CGFloat const kDisabledOpacity = 0.5f;
     _tintColor = tintColor;
     
     [self reloadLayer];
+}
+
+- (NSColor *)disabledBorderColor {
+    if (!_disabledBorderColor) return kDisabledBorderColor;
+    
+    return _disabledBorderColor;
 }
 
 - (void)setDisabledBorderColor:(NSColor *)disabledBorderColor {


### PR DESCRIPTION
Right now, you can't really set the knob's border color for disabled state. Which leaves you with this for dark backgrounds:
<img width="78" alt="screen shot 2016-03-02 at 9 03 23 am" src="https://cloud.githubusercontent.com/assets/4293969/13452101/f2fbfea4-e055-11e5-8628-98638ab46b20.png">

This PR gives the user the ability to modify this color via setter on ITSwitch or Interface Builder.
<img width="49" alt="screen shot 2016-03-02 at 9 05 02 am" src="https://cloud.githubusercontent.com/assets/4293969/13452103/f52e7eae-e055-11e5-8544-a14c84a7f374.png">

