### PR TITLE
Add option to set checked without animation

### DIFF
--- a/ITSwitch/ITSwitch.h
+++ b/ITSwitch/ITSwitch.h
@@ -29,4 +29,6 @@ IB_DESIGNABLE
  */
 @property (nonatomic, strong) IBInspectable NSColor *disabledBorderColor;
 
+- (void)setChecked:(BOOL)checked animated:(BOOL)animated;
+
 @end

--- a/ITSwitch/ITSwitch.m
+++ b/ITSwitch/ITSwitch.m
@@ -177,6 +177,18 @@ static CGFloat const kDisabledOpacity = 0.5f;
 // ----------------------------------------------------
 
 - (void)reloadLayer {
+    [self reloadLayerAnimated:NO];
+}
+
+- (void)reloadLayerAnimated:(BOOL)animated {
+    
+    [CATransaction begin];
+    [CATransaction setAnimationDuration: animated ? kAnimationDuration : 0.0];
+    
+    if (![self hasDragged]) {
+        CAMediaTimingFunction *function = [CAMediaTimingFunction functionWithControlPoints:0.25f :1.5f :0.5f :1.f];
+        [CATransaction setAnimationTimingFunction:function];
+    }
     
     if (([self hasDragged] && [self isDraggingTowardsOn]) || (![self hasDragged] && [self checked])) {
         _backgroundLayer.borderColor = [self.tintColor CGColor];
@@ -190,21 +202,6 @@ static CGFloat const kDisabledOpacity = 0.5f;
     
     self.knobLayer.frame = [self rectForKnob];
     self.knobInsideLayer.frame = self.knobLayer.bounds;
-}
-
-- (void)reloadLayerAnimated {
-    
-    // Wrap reloadLayerWithoutAnimation method around CATransaction
-    
-    [CATransaction begin];
-    [CATransaction setAnimationDuration:kAnimationDuration];
-    
-    if (![self hasDragged]) {
-        CAMediaTimingFunction *function = [CAMediaTimingFunction functionWithControlPoints:0.25f :1.5f :0.5f :1.f];
-        [CATransaction setAnimationTimingFunction:function];
-    }
-    
-    [self reloadLayer];
     
     [CATransaction commit];
 }
@@ -347,9 +344,9 @@ static CGFloat const kDisabledOpacity = 0.5f;
     }
     
     if (animated) {
-        [self reloadLayerAnimated];
+        [self reloadLayerAnimated:YES];
     } else {
-        [self reloadLayer];
+        [self reloadLayerAnimated:NO];
     }
 }
 


### PR DESCRIPTION
I found it useful to be able to set `checked` property programmatically without triggering animation. 

For some reason, I had to wrap even non-animated layer reloads around CATransition with animation duration equal to 0.0, otherwise the animation would still occur. So, the implementation isn't as elegant, but it works. 🚶 